### PR TITLE
Implement #each method and include Enumerable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Optionally:
 
     dns.include? 1  #=> false
 
+    dns.to_a        #=> [1]
+
 ### Tests
 
     ruby test/test.rb

--- a/lib/dumb_numb_set.rb
+++ b/lib/dumb_numb_set.rb
@@ -112,6 +112,18 @@ class DumbNumbSet
   def size
     @bitsets.length
   end
+
+  def each
+    @bitsets.each do |index, bitset|
+      offset = index * @div
+      (0..@div-1).each do |bit|
+        if bitset & (1 << bit) != 0
+          yield offset + bit
+        end
+      end
+    end
+  end
+  include Enumerable
 end
 
 # Custom marshal technique if MessagePack is available. Saves some bytes,

--- a/test/test.rb
+++ b/test/test.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift "#{File.expand_path(File.dirname(__FILE__))}/../lib"
 
 require 'test/unit'
 require 'dumb_numb_set'
+require 'set'
 
 class TestDumbNumbSet < Test::Unit::TestCase
   def setup
@@ -95,5 +96,31 @@ class TestDumbNumbSet < Test::Unit::TestCase
     assert_raises ArgumentError do
       @ns.add false
     end
+  end
+
+  def test_to_a
+    assert_equal [], @ns.to_a
+
+    @ns.add 1
+    assert_equal [1], @ns.to_a
+
+    @ns.add 255
+    assert_equal [1, 255], @ns.to_a
+
+    @ns.add 12345678
+    assert_equal [1, 255, 12345678], @ns.to_a
+
+    @ns.add 61
+    assert_equal [1, 255, 12345678, 61], @ns.to_a
+  end
+
+  def test_to_set
+    set = Set[0, 60, 61, 62, 1048576]
+
+    set.each do |v|
+      @ns.add v
+    end
+
+    assert_equal set, @ns.to_set
   end
 end


### PR DESCRIPTION
I have a production system which needs an efficient network coding of a Ruby set, and converts the set to an array at both ends. DumbNumbSet is great for the former, but only exposes `include?` for the latter.

So I've added a very simple `#each` method and added the Enumerable mixin, which solves this problem for me. Tests for `#to_a` and `#to_set` are included.

Thanks for your library!
